### PR TITLE
Add the async publish function

### DIFF
--- a/terraform/builds.tf
+++ b/terraform/builds.tf
@@ -4,25 +4,10 @@ data "archive_file" "builds_get_zip" {
   source_dir  = "${path.module}/.terraform/tmp/builds_get"
 }
 
-data "aws_iam_policy_document" "builds_get_policy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "builds_get_iam" {
-  name               = "${local.prefix}_builds_get_execution_role_${local.short_uuid}"
-  assume_role_policy = data.aws_iam_policy_document.builds_get_policy.json
-}
-
 resource "aws_lambda_function" "builds_get" {
   filename      = data.archive_file.builds_get_zip.output_path
   function_name = "${local.prefix}_builds_get_${local.short_uuid}"
-  role          = aws_iam_role.builds_get_iam.arn
+  role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
 
   source_code_hash = filebase64sha256(data.archive_file.builds_get_zip.output_path)

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,46 @@
+data "aws_iam_policy_document" "assume_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda_exec_role" {
+  name               = "${local.prefix}_execution_role_${local.short_uuid}"
+  assume_role_policy = data.aws_iam_policy_document.assume_policy.json
+}
+
+data "aws_iam_policy_document" "lambda_permissions" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+    resources = [
+      aws_s3_bucket.storage_bucket.arn,
+      "${aws_s3_bucket.storage_bucket.arn}/*",
+      aws_s3_bucket.moderation_bucket.arn,
+      "${aws_s3_bucket.moderation_bucket.arn}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "sqs:SendMessage",
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+    ]
+    resources = [
+      aws_sqs_queue.build_queue.arn,
+      aws_sqs_queue.build_dlq.arn,
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_permissions" {
+  role   = aws_iam_role.lambda_exec_role.name
+  policy = data.aws_iam_policy_document.lambda_permissions.json
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -21,4 +21,16 @@ resource "aws_sqs_queue" "build_queue" {
   delay_seconds             = var.sqs_visibility_delay
   max_message_size          = 2048
   message_retention_seconds = 86400
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.dlq.arn
+    maxReceiveCount     = 5
+  })
+}
+
+resource "aws_sqs_queue" "dlq" {
+  name                      = "${local.prefix}-build-dlq-${local.short_uuid}"
+  delay_seconds             = var.sqs_visibility_delay
+  max_message_size          = 2048
+  message_retention_seconds = 86400
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,6 +16,31 @@ resource "aws_s3_bucket" "storage_bucket" {
   acl    = "public-read"
 }
 
+resource "aws_s3_bucket" "moderation_bucket" {
+  bucket = "${local.prefix}-moderationbucket-${local.short_uuid}"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "moderation_bucket_public_access" {
+  bucket = aws_s3_bucket.moderation_bucket.id
+  block_public_acls = true
+  block_public_policy = true
+  ignore_public_acls = true
+  restrict_public_buckets = true
+}
+
 resource "aws_sqs_queue" "build_queue" {
   name                      = "${local.prefix}-build-queue-${local.short_uuid}"
   delay_seconds             = var.sqs_visibility_delay

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -48,12 +48,12 @@ resource "aws_sqs_queue" "build_queue" {
   message_retention_seconds = 86400
 
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.dlq.arn
+    deadLetterTargetArn = aws_sqs_queue.build_dlq.arn
     maxReceiveCount     = 5
   })
 }
 
-resource "aws_sqs_queue" "dlq" {
+resource "aws_sqs_queue" "build_dlq" {
   name                      = "${local.prefix}-build-dlq-${local.short_uuid}"
   delay_seconds             = var.sqs_visibility_delay
   max_message_size          = 2048

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -5,25 +5,10 @@ data "archive_file" "modules_get_zip" {
   source_dir  = "${path.module}/.terraform/tmp/modules_get"
 }
 
-data "aws_iam_policy_document" "modules_get_policy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "modules_get_iam" {
-  name               = "${local.prefix}_modules_get_execution_role_${local.short_uuid}"
-  assume_role_policy = data.aws_iam_policy_document.modules_get_policy.json
-}
-
 resource "aws_lambda_function" "modules_get" {
   filename      = data.archive_file.modules_get_zip.output_path
   function_name = "${local.prefix}_modules_get_${local.short_uuid}"
-  role          = aws_iam_role.modules_get_iam.arn
+  role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
 
   source_code_hash = filebase64sha256(data.archive_file.modules_get_zip.output_path)

--- a/terraform/publish.tf
+++ b/terraform/publish.tf
@@ -4,25 +4,10 @@ data "archive_file" "async_publish_zip" {
   source_dir  = "${path.module}/.terraform/tmp/async_publish"
 }
 
-data "aws_iam_policy_document" "async_publish_policy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "async_publish_iam" {
-  name               = "${local.prefix}_async_publish_execution_role_${local.short_uuid}"
-  assume_role_policy = data.aws_iam_policy_document.async_publish_policy.json
-}
-
 resource "aws_lambda_function" "async_publish" {
   filename      = data.archive_file.async_publish_zip.output_path
   function_name = "${local.prefix}_async_publish_${local.short_uuid}"
-  role          = aws_iam_role.async_publish_iam.arn
+  role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
 
   source_code_hash = filebase64sha256(data.archive_file.async_publish_zip.output_path)

--- a/terraform/publish.tf
+++ b/terraform/publish.tf
@@ -1,0 +1,51 @@
+data "archive_file" "async_publish_zip" {
+  type        = "zip"
+  output_path = "${path.module}/.terraform/tmp/async_publish.zip"
+  source_dir  = "${path.module}/.terraform/tmp/async_publish"
+}
+
+data "aws_iam_policy_document" "async_publish_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "async_publish_iam" {
+  name               = "${local.prefix}_async_publish_execution_role_${local.short_uuid}"
+  assume_role_policy = data.aws_iam_policy_document.async_publish_policy.json
+}
+
+resource "aws_lambda_function" "async_publish" {
+  filename      = data.archive_file.async_publish_zip.output_path
+  function_name = "${local.prefix}_async_publish_${local.short_uuid}"
+  role          = aws_iam_role.async_publish_iam.arn
+  handler       = "bundle.handler"
+
+  source_code_hash = filebase64sha256(data.archive_file.async_publish_zip.output_path)
+
+  runtime = "provided"
+  layers  = [aws_lambda_layer_version.deno_layer.arn]
+
+  timeout = 10
+
+  environment {
+    variables = {
+      "DENO_UNSTABLE"  = "1"
+      "HANDLER_EXT"    = "js"
+      "MONGO_URI"      = var.mongodb_uri
+      "STORAGE_BUCKET" = aws_s3_bucket.storage_bucket.id
+      "BUILD_QUEUE"    = aws_sqs_queue.build_queue.id
+    }
+  }
+}
+
+resource "aws_lambda_permission" "async_publish" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.async_publish.function_name
+  principal     = "sqs.amazonaws.com"
+  source_arn    = aws_sqs_queue.build_queue.arn
+}

--- a/terraform/webhook.tf
+++ b/terraform/webhook.tf
@@ -4,25 +4,10 @@ data "archive_file" "webhook_github_zip" {
   source_dir  = "${path.module}/.terraform/tmp/webhook_github"
 }
 
-data "aws_iam_policy_document" "webhook_github_policy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "webhook_github_iam" {
-  name               = "${local.prefix}_webhook_github_execution_role_${local.short_uuid}"
-  assume_role_policy = data.aws_iam_policy_document.webhook_github_policy.json
-}
-
 resource "aws_lambda_function" "webhook_github" {
   filename      = data.archive_file.webhook_github_zip.output_path
   function_name = "${local.prefix}_webhook_github_${local.short_uuid}"
-  role          = aws_iam_role.webhook_github_iam.arn
+  role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
 
   source_code_hash = filebase64sha256(data.archive_file.webhook_github_zip.output_path)

--- a/terraform/webhook.tf
+++ b/terraform/webhook.tf
@@ -34,11 +34,12 @@ resource "aws_lambda_function" "webhook_github" {
 
   environment {
     variables = {
-      "DENO_UNSTABLE"  = "1"
-      "HANDLER_EXT"    = "js"
-      "MONGO_URI"      = var.mongodb_uri
-      "STORAGE_BUCKET" = aws_s3_bucket.storage_bucket.id
-      "BUILD_QUEUE"    = aws_sqs_queue.build_queue.id
+      "DENO_UNSTABLE"     = "1"
+      "HANDLER_EXT"       = "js"
+      "MONGO_URI"         = var.mongodb_uri
+      "STORAGE_BUCKET"    = aws_s3_bucket.storage_bucket.id
+      "MODERATION_BUCKET" = aws_s3_bucket.moderation_bucket.id
+      "BUILD_QUEUE"       = aws_sqs_queue.build_queue.id
     }
   }
 }


### PR DESCRIPTION
PR adds mainly the async publish function but also:
- the dead letter queue
- the moderation s3 bucket
- refactors the iam permissions into a unified set of permissions applied to all functions

as a side note: I did some tests and keep getting 404s, i think it may be related to the API G deployment