### PR TITLE
Add resource tags & update storage bucket's acl

### DIFF
--- a/terraform/builds.tf
+++ b/terraform/builds.tf
@@ -26,6 +26,8 @@ resource "aws_lambda_function" "builds_get" {
       "BUILD_QUEUE"    = aws_sqs_queue.build_queue.id
     }
   }
+
+  tags = local.tags
 }
 
 resource "aws_lambda_permission" "builds_get" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "assume_policy" {
 resource "aws_iam_role" "lambda_exec_role" {
   name               = "${local.prefix}_execution_role_${local.short_uuid}"
   assume_role_policy = data.aws_iam_policy_document.assume_policy.json
+  tags               = local.tags
 }
 
 data "aws_iam_policy_document" "lambda_permissions" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,8 +17,32 @@ resource "aws_lambda_layer_version" "deno_layer" {
 
 resource "aws_s3_bucket" "storage_bucket" {
   bucket = "${local.prefix}-storagebucket-${local.short_uuid}"
-  acl    = "public-read"
+  acl    = "private"
   tags   = local.tags
+
+  cors_rule {
+    allowed_headers = []
+    allowed_methods = [
+      "GET",
+    ]
+    allowed_origins = [
+      "*",
+    ]
+    expose_headers  = []
+    max_age_seconds = 0
+  }
+
+  versioning {
+    enabled = false
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "storage_bucket_public_access" {
+  bucket                  = aws_s3_bucket.moderation_bucket.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }
 
 resource "aws_s3_bucket" "moderation_bucket" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,6 +3,10 @@ resource "random_uuid" "this" {}
 locals {
   short_uuid = substr(random_uuid.this.result, 0, 8)
   prefix     = "deno-registry2-${var.env}"
+  tags = {
+    "deno.land/x:environment" = var.env
+    "deno.land/x:instance"    = local.short_uuid
+  }
 }
 
 resource "aws_lambda_layer_version" "deno_layer" {
@@ -14,11 +18,13 @@ resource "aws_lambda_layer_version" "deno_layer" {
 resource "aws_s3_bucket" "storage_bucket" {
   bucket = "${local.prefix}-storagebucket-${local.short_uuid}"
   acl    = "public-read"
+  tags   = local.tags
 }
 
 resource "aws_s3_bucket" "moderation_bucket" {
   bucket = "${local.prefix}-moderationbucket-${local.short_uuid}"
   acl    = "private"
+  tags   = local.tags
 
   versioning {
     enabled = true
@@ -46,6 +52,7 @@ resource "aws_sqs_queue" "build_queue" {
   delay_seconds             = var.sqs_visibility_delay
   max_message_size          = 2048
   message_retention_seconds = 86400
+  tags                      = local.tags
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.build_dlq.arn
@@ -58,4 +65,5 @@ resource "aws_sqs_queue" "build_dlq" {
   delay_seconds             = var.sqs_visibility_delay
   max_message_size          = 2048
   message_retention_seconds = 86400
+  tags                      = local.tags
 }

--- a/terraform/meta.tf
+++ b/terraform/meta.tf
@@ -17,6 +17,7 @@ terraform {
 resource "aws_s3_bucket" "terraform_state" {
   bucket = "terraform-state-${local.short_uuid}"
   acl    = "private"
+  tags   = local.tags
   versioning {
     enabled = true
   }

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -57,25 +57,10 @@ data "archive_file" "modules_list_zip" {
   source_dir  = "${path.module}/.terraform/tmp/modules_list"
 }
 
-data "aws_iam_policy_document" "modules_list_policy" {
-  statement {
-    actions = ["sts:AssumeRole"]
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "modules_list_iam" {
-  name               = "${local.prefix}_modules_list_execution_role_${local.short_uuid}"
-  assume_role_policy = data.aws_iam_policy_document.modules_list_policy.json
-}
-
 resource "aws_lambda_function" "modules_list" {
   filename      = data.archive_file.modules_list_zip.output_path
   function_name = "${local.prefix}_modules_list_${local.short_uuid}"
-  role          = aws_iam_role.modules_list_iam.arn
+  role          = aws_iam_role.lambda_exec_role.arn
   handler       = "bundle.handler"
 
   source_code_hash = filebase64sha256(data.archive_file.modules_list_zip.output_path)

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -25,6 +25,8 @@ resource "aws_lambda_function" "modules_get" {
       "MONGO_URI"     = var.mongodb_uri
     }
   }
+
+  tags = local.tags
 }
 
 resource "aws_lambda_permission" "modules_get" {
@@ -77,6 +79,8 @@ resource "aws_lambda_function" "modules_list" {
       "MONGO_URI"     = var.mongodb_uri
     }
   }
+
+  tags = local.tags
 }
 
 resource "aws_lambda_permission" "modules_list" {

--- a/terraform/publish.tf
+++ b/terraform/publish.tf
@@ -26,6 +26,8 @@ resource "aws_lambda_function" "async_publish" {
       "BUILD_QUEUE"    = aws_sqs_queue.build_queue.id
     }
   }
+
+  tags = local.tags
 }
 
 resource "aws_lambda_permission" "async_publish" {

--- a/terraform/webhook.tf
+++ b/terraform/webhook.tf
@@ -27,6 +27,8 @@ resource "aws_lambda_function" "webhook_github" {
       "BUILD_QUEUE"       = aws_sqs_queue.build_queue.id
     }
   }
+
+  tags = local.tags
 }
 
 resource "aws_lambda_permission" "webhook_github" {


### PR DESCRIPTION
Cost Allocation Tags aren't supported by Terraform AWS provider yet, but this PR adds the necessary tags to be able to the Cost Allocation Tags features in the Billing console

I noticed the `public-read` acl actually produced different settings than the existing bucket deployed via sam, so I tweaked that as well